### PR TITLE
fix orange metal catalyst recipe

### DIFF
--- a/src/main/java/dev/arbor/gtnn/data/recipes/RocketFuel.kt
+++ b/src/main/java/dev/arbor/gtnn/data/recipes/RocketFuel.kt
@@ -124,7 +124,6 @@ object RocketFuel {
             .inputItems(ChemicalHelper.get(TagPrefix.dust, GTMaterials.Vanadium, 1))
             .inputItems(ChemicalHelper.get(TagPrefix.dust, GTMaterials.Palladium, 1))
             .outputItems(ChemicalHelper.get(TagPrefix.dust, GTNNMaterials.OrangeMetalCatalyst, 64))
-            .outputItems(ChemicalHelper.get(TagPrefix.dust, GTNNMaterials.OrangeMetalCatalyst, 32))
             .circuitMeta(32)
             .duration(GTNNRecipes.dur(8.0)).EUt(GTValues.VA[GTValues.HV].toLong()).save(provider)
 


### PR DESCRIPTION
GT mixers only have one output slot, so this recipe never worked as there is not enough space for its outputs.  This reduces the output to 1 stack, which should be fine balance wise.

Reported in https://github.com/jmoiron/quantum-skies/issues/21