### PR TITLE
update for gtm 1.6.4, fix the enderlinkCover

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -31,8 +31,8 @@ dependencyResolutionManagement {
         def ad_astra_version = "1.15.18"
         def resourcefullib_version = "2.1.23"
         def resourcefulconfig_version = "2.1.2"
-        def gtmVersion = "1.6.2"
-        def ldLibVersion = "1.0.31"
+        def gtmVersion = "1.6.4"
+        def ldLibVersion = "1.0.35"
         def shimmerVersion = "0.2.4"
 
         // Libs

--- a/src/main/java/dev/arbor/gtnn/temp/AbstractEnderLinkCover.java
+++ b/src/main/java/dev/arbor/gtnn/temp/AbstractEnderLinkCover.java
@@ -163,7 +163,7 @@ public abstract class AbstractEnderLinkCover<T extends VirtualEntry> extends Cov
         if (permission == Permissions.PUBLIC)
             return null;
         else if (owner instanceof PlayerOwner playerOwner)
-            return playerOwner.getPlayerUUID();
+            return playerOwner.getUUID();
         else if (owner instanceof ArgonautsOwner argonautsOwner)
             return argonautsOwner.getPlayerUUID();
         else if (owner instanceof FTBOwner ftbOwner)


### PR DESCRIPTION
gtm1.6.4版本修改了player的UUID方法，导致末影覆盖板坏区块