### PR TITLE
fix ender link owner not load

### DIFF
--- a/src/main/java/dev/arbor/gtnn/temp/MachineOwnerPayload.java
+++ b/src/main/java/dev/arbor/gtnn/temp/MachineOwnerPayload.java
@@ -18,6 +18,6 @@ public class MachineOwnerPayload extends ObjectTypedPayload<IMachineOwner> {
 
     @Override
     public void deserializeNBT(Tag tag) {
-        payload.save((CompoundTag) tag);
+        payload = IMachineOwner.create((CompoundTag) tag);
     }
 }


### PR DESCRIPTION
修复带末影覆盖板的机器的区块不能正确加载